### PR TITLE
Update PointerSection.qml

### DIFF
--- a/sections/PointerSection.qml
+++ b/sections/PointerSection.qml
@@ -60,7 +60,7 @@ Ui.SectionBody {
 
     Ui.SwitchRow {
       label: "Tap to click"
-      checked: app.hyprValue("tap-to-click", true) === true
+      checked: app.hyprValue("tap_to_click", true) === true
       onRequested: function(next) { app.setHypr("tap-to-click", next ? "true" : "false") }
       changed: app.isChanged("tap-to-click")
       onResetRequested: app.resetSetting("tap-to-click")


### PR DESCRIPTION
Corrected hyprValue "tap_to_click" to use the underscores instead of dashes, eliminating errors when changing the tap to click setting.