### PR TITLE
Update a plugin without a terminal over the window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,30 @@ believe.
 ## The Plugins page
 
 Add and remove hand off to the Omarchy flows in a terminal, because both ask
-questions and print what they did. The update check fetches every plugin at
+questions and print what they did. **Update does not.** `omarchy-plugin-update
+<id> --yes` is entirely non-interactive — the diff and the confirm are the half
+`--yes` skips — and a terminal opening over this window was the whole of what
+that bought. So the row does the asking instead: how many commits are coming,
+and what the first three of them say, read off the same `FETCH_HEAD` the count
+came from, at no extra network cost.
+
+**A plugin cannot update another plugin and stay on screen.** The shell watches
+`~/.config/omarchy/plugins` with `inotifywait -m -r` and calls
+`reloadPlugins()` on any change under it, which unloads every plugin widget —
+including the bar widget hosting this window. A `git merge` is a change under
+it, so the window goes. Deferring `omarchy-plugin-update`'s own
+`rescanPlugins` does not help; the watcher has already fired. Two things
+follow, and both are the design rather than a workaround:
+
+- **The update is detached** (`setsid`, re-entering as `plugin update-run`).
+  A child of the window would be killed part-way through its own merge.
+- **It reports into the cache, not up its own stdout.** `running` says a
+  spinner is owed, `last` says how it went. The page polls while something is
+  in flight and picks up an update already running when it is built again, so
+  the answer waits for the window to come back rather than dying with it. The
+  page says up front that it will close, because it will.
+
+The update check fetches every plugin at
 once and prints each verdict as it lands, so spinners retire one at a time
 rather than all at the end; the verdicts outlive the sweep in
 `~/.cache/omarchy/omasettings/plugin-updates.json`, since a check costs a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,8 +412,10 @@ came from, at no extra network cost.
 `reloadPlugins()` on any change under it, which unloads every plugin widget —
 including the bar widget hosting this window. A `git merge` is a change under
 it, so the window goes. Deferring `omarchy-plugin-update`'s own
-`rescanPlugins` does not help; the watcher has already fired. Two things
-follow, and both are the design rather than a workaround:
+`rescanPlugins` does not help; the watcher has already fired. (This also
+bites while testing: a `git` command run by hand inside any plugin directory
+closes the window, so rewind a plugin *before* opening it, not after.) Three
+things follow, and they are the design rather than a workaround:
 
 - **The update is detached** (`setsid`, re-entering as `plugin update-run`).
   A child of the window would be killed part-way through its own merge.
@@ -422,6 +424,15 @@ follow, and both are the design rather than a workaround:
   in flight and picks up an update already running when it is built again, so
   the answer waits for the window to come back rather than dying with it. The
   page says up front that it will close, because it will.
+- **It summons the window back.** The job that outlived the window is the only
+  thing left that knows it should return, so it waits for
+  `omarchy-shell shell ping` to answer, lets the teardown settle, and then
+  calls `omasettings showPage plugins` until the layer is actually there — the
+  IPC call returns nothing either way, and a summon eaten by a dying panel
+  looks exactly like one that worked. Whether to return is decided *before*
+  the update, while the window is still up to be asked: afterwards there is no
+  telling a window that was torn down from one the reader had closed, and
+  opening a window nobody asked for is worse than not returning to one.
 
 The update check fetches every plugin at
 once and prints each verdict as it lands, so spinners retire one at a time

--- a/Panel.qml
+++ b/Panel.qml
@@ -19,6 +19,20 @@ BarWidget {
   readonly property bool opened: windowLoader.item ? windowLoader.item.shown : false
 
   function show() { windowLoader.active = true; if (windowLoader.item) windowLoader.item.show() }
+  // Opening on a named page is how a job that had to tear this window down
+  // brings it back where it was: the loader is asynchronous, so the page is
+  // remembered until there is an item to give it to.
+  property string pendingPage: ""
+  function showPage(page) {
+    pendingPage = String(page || "")
+    show()
+    applyPendingPage()
+  }
+  function applyPendingPage() {
+    if (pendingPage === "" || !windowLoader.item) return
+    windowLoader.item.pageId = pendingPage
+    pendingPage = ""
+  }
   function hide() { if (windowLoader.item) windowLoader.item.hide() }
   function open() { show() }
   function close() { hide() }
@@ -33,6 +47,7 @@ BarWidget {
   IpcHandler {
     target: "omasettings"
     function show(): void { root.show() }
+    function showPage(page: string): void { root.showPage(page) }
     function hide(): void { root.hide() }
     function open(): void { root.open() }
     function close(): void { root.close() }
@@ -44,7 +59,10 @@ BarWidget {
     active: false
     asynchronous: true
     source: "SettingsWindow.qml"
-    onLoaded: if (item) item.show()
+    onLoaded: {
+      if (item) item.show()
+      root.applyPendingPage()
+    }
   }
 
   BarIconButton {

--- a/bin/omasettings
+++ b/bin/omasettings
@@ -28,6 +28,9 @@
 set -uo pipefail
 
 OMASETTINGS_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)"
+# A detached update re-enters here, so this script has to be able to name
+# itself: it is started from the window's own copy, which is not on any PATH.
+OMASETTINGS_BIN="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 for module in core store hypr devices monitors shell_config compose plugins menu herdr tmux neovim bindings wifi bluetooth power audio setters state; do
   # shellcheck source=/dev/null

--- a/lib/plugins.sh
+++ b/lib/plugins.sh
@@ -167,13 +167,40 @@ self_check() {
 # --yes. Only the asking needed a terminal, and this window has already asked
 # — the row says how many commits are coming and what they say.
 #
-# It does not run as a child of the window, though. Its last act is
-# `omarchy-shell shell rescanPlugins`, which unloads and reloads every
-# plugin's QML — this window included. A child of the window would be killed
-# part-way through its own `git merge`, and the answer would die with the
-# window that asked. So the work is detached, and it says what it did in the
-# cache the page already reads: whoever is looking when it lands sees it, and
-# so does the window that comes back afterwards.
+# It does not run as a child of the window, though. The shell watches the
+# plugins directory with `inotifywait -m -r` and reloads every plugin widget
+# on any change under it — this window's host included — so a `git merge` in
+# there takes the window down while the merge is still running. A child of it
+# would be killed part-way through, and the answer would die with the window
+# that asked. So the work is detached, says what it did in the cache the page
+# reads, and then brings the window back.
+
+# Bringing the window back afterwards. The reload takes it down mid-update, so
+# the job that survived is the only thing left that knows it should return —
+# and it has to wait its turn: the shell may still be tearing down, rebuilding,
+# or (having been asked to rescan) starting the plugins up again. Summoning
+# into that lands on the panel that is going away, so this waits for the shell
+# to answer at all, lets the teardown settle, and then keeps asking.
+reopen_window() {
+  local i
+  for i in $(seq 1 60); do
+    [[ -n $(omarchy-shell shell ping 2>/dev/null) ]] && break
+    sleep 0.5
+  done
+  sleep 0.6
+  for i in $(seq 1 20); do
+    omarchy-shell omasettings showPage plugins >/dev/null 2>&1
+    window_open && return 0
+    sleep 0.5
+  done
+}
+
+# The layer, not the exit code: the IPC call returns nothing either way, and a
+# summon eaten by a dying panel looks exactly like one that worked.
+window_open() {
+  hyprctl layers -j 2>/dev/null | jq -e '..|select(.namespace? == "omasettings")' >/dev/null 2>&1
+}
+
 plugin_update_start() {
   local id=$1
 
@@ -181,7 +208,14 @@ plugin_update_start() {
     '.running = ((.running // {}) | .[$id] = $at) | .last = ((.last // {}) | del(.[$id]))' \
     <<<"$(plugin_updates_cache)" 2>/dev/null | write_update_cache
 
-  setsid bash "$OMASETTINGS_BIN" plugin update-run "$id" >/dev/null 2>&1 &
+  # Whether to come back is decided here, while the window is still up to be
+  # asked. A summon after the fact cannot tell a window that was torn down
+  # from one the reader had already closed, and opening a window nobody asked
+  # for is worse than not returning to one.
+  local reopen=0
+  window_open && reopen=1
+
+  setsid bash "$OMASETTINGS_BIN" plugin update-run "$id" "$reopen" >/dev/null 2>&1 &
   disown 2>/dev/null || true
 
   # The window wants the spinner now, not at the next poll.
@@ -189,7 +223,7 @@ plugin_update_start() {
 }
 
 plugin_update_run() {
-  local id=$1 out rc msg
+  local id=$1 reopen=${2:-0} out rc msg
   out=$(omarchy-plugin-update "$id" --yes 2>&1)
   rc=$?
 
@@ -211,4 +245,9 @@ plugin_update_run() {
            | .changes = ((.changes // {}) | del(.[$id]))
          else . end' \
     <<<"$(plugin_updates_cache)" 2>/dev/null | write_update_cache
+
+  # The verdict is written before the window is asked back, so the page it
+  # opens on already has it.
+  (( reopen == 1 )) && reopen_window
+  return 0
 }

--- a/lib/plugins.sh
+++ b/lib/plugins.sh
@@ -15,8 +15,16 @@ UPDATE_CACHE="${OMASETTINGS_UPDATE_CACHE:-${XDG_CACHE_HOME:-$HOME_DIR/.cache}/om
 # anything else we did not write this second.
 plugin_updates_cache() {
   read_file "$UPDATE_CACHE" \
-    | jq -c '{ checkedAt: (.checkedAt // 0), results: (.results // {}) }' 2>/dev/null && return
-  echo '{"checkedAt":0,"results":{}}'
+    | jq -c --argjson now "$(date +%s)" '
+        { checkedAt: (.checkedAt // 0),
+          results: (.results // {}),
+          changes: (.changes // {}),
+          # An update detached from this window can be killed with the shell
+          # it was started from, and would then spin forever. A marker older
+          # than the longest plausible update is not an update in flight.
+          running: ((.running // {}) | with_entries(select(.value > $now - 600))),
+          last: (.last // {}) }' 2>/dev/null && return
+  echo '{"checkedAt":0,"results":{},"changes":{},"running":{},"last":{}}'
 }
 
 # Same for putting it back: a fresh random sibling, renamed into place, so a
@@ -74,16 +82,32 @@ plugin_updates() {
            timeout "${FETCH_TIMEOUT:-30}" git -C "$repo" fetch -q origin HEAD 2>/dev/null; then
         # The bounds are spelled out rather than shared: this runs in a bash
         # xargs started, which never sourced anything of ours.
-        printf "%s\t%s\n" "$id" \
-          "$(timeout 10 git -C "$repo" rev-list --count HEAD..FETCH_HEAD 2>/dev/null | head -c 32 || echo 0)"
+        # Double quotes on purpose: this whole worker is a single-quoted
+        # string, so a single quote here ends it and the script stops parsing.
+        #
+        # The subjects come off the FETCH_HEAD the count was just taken from,
+        # so saying what is coming costs no second round trip. They stand in
+        # for the diff the terminal used to print: enough to decide with,
+        # short enough to sit on a row.
+        printf "%s\t%s\t%s\n" "$id" \
+          "$(timeout 10 git -C "$repo" rev-list --count HEAD..FETCH_HEAD 2>/dev/null | head -c 32 || echo 0)" \
+          "$(timeout 10 git -C "$repo" log --format=%s -n 3 HEAD..FETCH_HEAD 2>/dev/null \
+             | tr "\t|" "  " | paste -s -d "|" - | head -c 300)"
       else
         printf "%s\t-2\n" "$id"
       fi' _ {}
   } | tee "$out"
 
-  jq -Rn --argjson at "$(date +%s)" '
-    { checkedAt: $at,
-      results: ([inputs | split("\t") | select(length == 2) | { key: .[0], value: (.[1] | tonumber) }] | from_entries) }' \
+  # What an update said about itself outlives a sweep: the sweep is about the
+  # counts, and rebuilding the whole document would throw away the answer the
+  # page is still showing.
+  jq -Rn --argjson at "$(date +%s)" --argjson prev "$(plugin_updates_cache)" '
+    [inputs | split("\t") | select(length >= 2)] as $rows
+    | { checkedAt: $at,
+        results: ([$rows[] | { key: .[0], value: (.[1] | tonumber) }] | from_entries),
+        changes: ([$rows[] | select((.[2] // "") != "") | { key: .[0], value: .[2] }] | from_entries),
+        running: ($prev.running // {}),
+        last: ($prev.last // {}) }' \
     <"$out" 2>/dev/null | write_update_cache
   rm -f "$out"
 }
@@ -134,4 +158,57 @@ self_check() {
     <<<"$(plugin_updates_cache)" 2>/dev/null | write_update_cache
 
   self_update_state
+}
+
+# ---------------------------------------------------------- applying one
+#
+# `omarchy-plugin-update <id> --yes` is entirely non-interactive: the diff and
+# the gum confirm it prints are the *unattended* half of the flow, skipped by
+# --yes. Only the asking needed a terminal, and this window has already asked
+# — the row says how many commits are coming and what they say.
+#
+# It does not run as a child of the window, though. Its last act is
+# `omarchy-shell shell rescanPlugins`, which unloads and reloads every
+# plugin's QML — this window included. A child of the window would be killed
+# part-way through its own `git merge`, and the answer would die with the
+# window that asked. So the work is detached, and it says what it did in the
+# cache the page already reads: whoever is looking when it lands sees it, and
+# so does the window that comes back afterwards.
+plugin_update_start() {
+  local id=$1
+
+  jq -c --arg id "$id" --argjson at "$(date +%s)" \
+    '.running = ((.running // {}) | .[$id] = $at) | .last = ((.last // {}) | del(.[$id]))' \
+    <<<"$(plugin_updates_cache)" 2>/dev/null | write_update_cache
+
+  setsid bash "$OMASETTINGS_BIN" plugin update-run "$id" >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+
+  # The window wants the spinner now, not at the next poll.
+  plugin_updates_cache
+}
+
+plugin_update_run() {
+  local id=$1 out rc msg
+  out=$(omarchy-plugin-update "$id" --yes 2>&1)
+  rc=$?
+
+  # Upstream's own last line is the message worth showing: "Updated x.",
+  # "x is up to date.", or why it refused.
+  msg=$(printf '%s' "$out" | grep -v '^[[:space:]]*$' | tail -n 1 | head -c 400)
+  if [[ -z $msg ]]; then
+    (( rc == 0 )) && msg="Updated." || msg="Update failed."
+  fi
+
+  # A successful update makes the recorded count a lie; the cheapest honest
+  # answer is zero, which is what a fresh check would find anyway.
+  jq -c --arg id "$id" --argjson ok "$(( rc == 0 ? 1 : 0 ))" --arg msg "$msg" \
+     --argjson at "$(date +%s)" '
+       .running = ((.running // {}) | del(.[$id]))
+       | .last = ((.last // {}) | .[$id] = { ok: ($ok == 1), message: $msg, at: $at })
+       | if $ok == 1 then
+           .results = ((.results // {}) | .[$id] = 0)
+           | .changes = ((.changes // {}) | del(.[$id]))
+         else . end' \
+    <<<"$(plugin_updates_cache)" 2>/dev/null | write_update_cache
 }

--- a/lib/setters.sh
+++ b/lib/setters.sh
@@ -192,11 +192,14 @@ plugin_cmd() {
     remove)
       setsid bash -lc "omarchy-launch-floating-terminal-with-presentation $(printf '%q' "omarchy-plugin-remove $(printf '%q' "$id")")" >/dev/null 2>&1 &
       disown 2>/dev/null || true ;;
-    # Updating shows the incoming diff and asks before pulling, so it gets a
-    # terminal of its own too.
-    update)
-      setsid bash -lc "omarchy-launch-floating-terminal-with-presentation $(printf '%q' "omarchy-plugin-update $(printf '%q' "$id")")" >/dev/null 2>&1 &
-      disown 2>/dev/null || true ;;
+    # Updating asks nothing this window has not already asked — the row says
+    # how many commits are coming and what they say — so no terminal. It does
+    # detach, because upstream's last act reloads every plugin's QML and would
+    # otherwise kill the update it started. See plugin_update_start.
+    update) plugin_update_start "$id" ;;
+    # Not for the window to call: this is the detached half, re-entering to do
+    # the work after rescanPlugins has torn the caller down.
+    update-run) plugin_update_run "$id" ;;
     *) die "unknown plugin action '$action'" ;;
   esac
 }

--- a/lib/setters.sh
+++ b/lib/setters.sh
@@ -199,7 +199,7 @@ plugin_cmd() {
     update) plugin_update_start "$id" ;;
     # Not for the window to call: this is the detached half, re-entering to do
     # the work after rescanPlugins has torn the caller down.
-    update-run) plugin_update_run "$id" ;;
+    update-run) plugin_update_run "$id" "${3:-0}" ;;
     *) die "unknown plugin action '$action'" ;;
   esac
 }

--- a/sections/PluginsSection.qml
+++ b/sections/PluginsSection.qml
@@ -45,15 +45,25 @@ Ui.SectionBody {
     catchUp.restart()
   }
 
+  // The window does close while an update lands, and saying so is the only
+  // honest option: the shell watches the plugins directory with inotifywait
+  // and reloads every plugin widget — this window's host included — on any
+  // file change under it. A git merge is a file change, so no plugin can
+  // update another one and stay on screen. What it can do is come back and
+  // still know what happened.
+  readonly property string headerNote:
+    "Taking an update reloads the shell's plugins, so this window closes while it lands — reopen it and the plugin will say how it went."
+
   // Updating happens without a terminal: upstream's flow is non-interactive
   // with --yes, and the only thing the terminal added was the question this
   // page has already answered — the row says how many commits are coming and
   // what they say.
   //
-  // The update itself is detached, because upstream ends by reloading every
-  // plugin's QML and this window goes with them. So the page does not own the
-  // work; it watches the cache the work reports into, and picks up an update
-  // already in flight when it is built again.
+  // The work is detached from the window for the same reason: a child process
+  // would be killed part-way through its own git merge when the reload above
+  // arrives. So the page does not own the work; it watches the cache the work
+  // reports into, and picks up an update already in flight when it is built
+  // again.
   property var updating: (app.state.pluginUpdates && app.state.pluginUpdates.running) || ({})
   property var updateResult: (app.state.pluginUpdates && app.state.pluginUpdates.last) || ({})
 
@@ -213,7 +223,10 @@ Ui.SectionBody {
         readonly property var result: page.updateResult[modelData.id]
         // The sweep joins the subjects with a pipe, having taken any out of
         // the subjects themselves, so one line survives its own transport.
-        readonly property string incoming: (page.changes[modelData.id] || "").split("|").join(" · ")
+        // What is coming is worth saying until something has been tried; after
+        // that the outcome is the newer fact and the row says that instead.
+        readonly property string incoming: (updating || result)
+          ? "" : (page.changes[modelData.id] || "").split("|").join(" · ")
 
         width: parent.width
         label: modelData.name

--- a/sections/PluginsSection.qml
+++ b/sections/PluginsSection.qml
@@ -45,14 +45,13 @@ Ui.SectionBody {
     catchUp.restart()
   }
 
-  // The window does close while an update lands, and saying so is the only
-  // honest option: the shell watches the plugins directory with inotifywait
-  // and reloads every plugin widget — this window's host included — on any
-  // file change under it. A git merge is a file change, so no plugin can
-  // update another one and stay on screen. What it can do is come back and
-  // still know what happened.
+  // The window cannot stay up through an update: the shell watches the plugins
+  // directory with inotifywait and reloads every plugin widget — this window's
+  // host included — on any file change under it, and a git merge is one. What
+  // it can do is come back, which the job that outlived it asks for, so the
+  // reader is told to expect the blink rather than left to explain it.
   readonly property string headerNote:
-    "Taking an update reloads the shell's plugins, so this window closes while it lands — reopen it and the plugin will say how it went."
+    "Taking an update reloads the shell's plugins, so this window closes for a moment and comes back here with the result."
 
   // Updating happens without a terminal: upstream's flow is non-interactive
   // with --yes, and the only thing the terminal added was the question this

--- a/sections/PluginsSection.qml
+++ b/sections/PluginsSection.qml
@@ -18,10 +18,14 @@ Ui.SectionBody {
   // Seeded from the last sweep's cache, so leaving the page and coming back
   // shows what was already learned instead of an empty list.
   property var behind: (app.state.pluginUpdates && app.state.pluginUpdates.results) || ({})
+  // What the incoming commits say, keyed by plugin id — the sweep read them
+  // off the same FETCH_HEAD it counted, so a row can say what an update is
+  // before it is taken.
+  property var changes: (app.state.pluginUpdates && app.state.pluginUpdates.changes) || ({})
   property double checkedAt: (app.state.pluginUpdates && app.state.pluginUpdates.checkedAt) || 0
   property bool checked: checkedAt > 0
 
-  // Adding, removing and updating hand off to a terminal flow that outlives
+  // Adding and removing hand off to a terminal flow that outlives
   // the window's own refresh, so the list is re-read a few times afterwards
   // rather than once, 400ms later, while the clone is still downloading.
   Timer {
@@ -39,6 +43,79 @@ Ui.SectionBody {
     app.run(args)
     catchUp.ticks = 0
     catchUp.restart()
+  }
+
+  // Updating happens without a terminal: upstream's flow is non-interactive
+  // with --yes, and the only thing the terminal added was the question this
+  // page has already answered — the row says how many commits are coming and
+  // what they say.
+  //
+  // The update itself is detached, because upstream ends by reloading every
+  // plugin's QML and this window goes with them. So the page does not own the
+  // work; it watches the cache the work reports into, and picks up an update
+  // already in flight when it is built again.
+  property var updating: (app.state.pluginUpdates && app.state.pluginUpdates.running) || ({})
+  property var updateResult: (app.state.pluginUpdates && app.state.pluginUpdates.last) || ({})
+
+  readonly property bool anyUpdating: {
+    for (var k in updating) return true
+    return false
+  }
+  onAnyUpdatingChanged: if (anyUpdating) updateWatch.start()
+  // An update that outlived the window is still running when the page is
+  // built again, and its spinner has to come back with it.
+  Component.onCompleted: if (anyUpdating) updateWatch.start()
+
+  function updateOne(id) {
+    if (updateProc.running || page.anyUpdating) return
+    // Optimistic, so the spinner starts on the click rather than on the poll:
+    // the reply below replaces it either way.
+    var next = {}
+    for (var k in page.updating) next[k] = page.updating[k]
+    next[id] = 1
+    page.updating = next
+    startProc.command = ["bash", page.app.helperPath, "plugin", "update", id]
+    startProc.running = true
+  }
+
+  // Both the start and the poll return the same document — the cache — so
+  // there is one place that reads it.
+  function absorb(text) {
+    try {
+      var d = JSON.parse(text)
+      if (!d) return
+      page.updating = d.running || ({})
+      page.updateResult = d.last || ({})
+      page.behind = d.results || page.behind
+      page.changes = d.changes || page.changes
+      if (d.checkedAt) page.checkedAt = d.checkedAt
+    } catch (e) {}
+  }
+
+  Process {
+    id: startProc
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: page.absorb(text) }
+    onRunningChanged: if (!running && page.anyUpdating) updateWatch.start()
+  }
+
+  // Only while something is in flight, and only while this page is the one on
+  // screen: a plugin update is a git fetch and a merge, not a state anyone
+  // needs polled the rest of the time.
+  Timer {
+    id: updateWatch
+    interval: 1000
+    repeat: true
+    running: false
+    onTriggered: {
+      if (!page.anyUpdating) { stop(); page.app.refresh(); return }
+      if (!watchProc.running) watchProc.running = true
+    }
+  }
+
+  Process {
+    id: watchProc
+    command: ["bash", page.app.helperPath, "plugin", "updates-cached"]
+    stdout: StdioCollector { waitForEnd: true; onStreamFinished: page.absorb(text) }
   }
 
   function checkUpdates() {
@@ -131,7 +208,12 @@ Ui.SectionBody {
         id: pluginRow
         required property var modelData
         readonly property int commitsBehind: page.behind[modelData.id] === undefined ? 0 : page.behind[modelData.id]
-        readonly property bool busy: page.checking[modelData.id] === true
+        readonly property bool updating: page.updating[modelData.id] !== undefined
+        readonly property bool busy: page.checking[modelData.id] === true || updating
+        readonly property var result: page.updateResult[modelData.id]
+        // The sweep joins the subjects with a pipe, having taken any out of
+        // the subjects themselves, so one line survives its own transport.
+        readonly property string incoming: (page.changes[modelData.id] || "").split("|").join(" · ")
 
         width: parent.width
         label: modelData.name
@@ -140,7 +222,9 @@ Ui.SectionBody {
           + (commitsBehind === -1 ? " · not a git checkout"
              : commitsBehind === -2 ? " · could not reach its remote"
              : commitsBehind > 0 ? " · " + commitsBehind + (commitsBehind === 1 ? " commit" : " commits") + " behind"
+                                   + (incoming ? " · " + incoming : "")
              : "")
+          + (updating ? " · updating…" : result ? " · " + result.message : "")
 
         Row {
           anchors.right: parent.right
@@ -168,13 +252,15 @@ Ui.SectionBody {
           Button {
             anchors.verticalCenter: parent.verticalCenter
             visible: pluginRow.commitsBehind > 0
-            text: "Update"
+            enabled: !page.anyUpdating
+            opacity: enabled ? 1 : 0.5
+            text: pluginRow.updating ? "Updating…" : "Update"
             bordered: true
             foreground: Ui.Palette.foreground
             accent: Ui.Palette.accent
             fontFamily: Ui.Palette.fontFamily
             fontSize: Style.font.caption
-            onClicked: page.handOff(["plugin", "update", pluginRow.modelData.id])
+            onClicked: page.updateOne(pluginRow.modelData.id)
           }
 
           // Only a plugin you installed can be removed; the built-in ones


### PR DESCRIPTION
Updating a plugin from the Plugins page opened a floating terminal on top of the settings window. This replaces that with a spinner, the incoming commits, and the verdict — in the window.

## Why the terminal was there

`omarchy-plugin-update <id>` prints a diff and asks before pulling, so it needed somewhere to ask. With `--yes` it is entirely non-interactive: the diff and the `gum confirm` are exactly the half `--yes` skips. Nothing else about it wanted a terminal.

So the page does the asking instead. The update sweep now also reads the first three incoming commit subjects off the same `FETCH_HEAD` it took the count from — no extra network — and a row that is behind says what the update actually is:

```
AirPods
io.github.thisisgm.omapods · 5 commits behind · Merge pull request #38 from
thisisgm/fix/harden-the-user-unit · chore: bump the plugin version to 1.3.6 · …
```

Once a row has been tried, the outcome replaces the subjects — it is the newer of the two facts, and both at once is a paragraph. The verdict is upstream's own last line, kept whether it succeeded or not, so a refusal ("cannot fast-forward 'x'; you have local changes") now lands on the row instead of flashing past in a terminal that has already closed.

## The window still closes, and that is not fixable from here

`PluginRegistry` watches `~/.config/omarchy/plugins` with `inotifywait -m -r` and calls `reloadPlugins()` on any change under it, which unloads **every** plugin widget — including the bar widget hosting this window. A `git merge` is such a change, so no plugin can update another plugin and stay on screen. Deferring `omarchy-plugin-update`'s own `rescanPlugins` does not help; the watcher has already fired. (An earlier attempt to shim that call out is not in this branch — it was solving the wrong half.)

What the window can do is survive it and come back:

- **The update is detached** (`setsid`, re-entering as `plugin update-run`). A child of the window would be killed part-way through its own `git merge`.
- **It reports into the cache, not up its own stdout.** `running` says a spinner is owed, `last` says how it went. The page polls while something is in flight and picks up an update already running when it is built again, so the answer waits for the window rather than dying with it.
- **It summons the window back**, the way Plug does: wait for `omarchy-shell shell ping`, let the teardown settle, then call `omasettings showPage plugins` until the layer is really there — the IPC call returns nothing either way, and a summon eaten by a dying panel looks exactly like one that worked. Whether to return is decided *before* the update, while the window is still up to be asked; afterwards there is no telling a window that was torn down from one the reader had closed, and opening a window nobody asked for is worse than not returning to one.

`Panel.qml` gains `showPage(page)` so the summon lands where you left off rather than on Appearance. The loader is asynchronous, so the page is held until there is an item to give it to.

The page says all this in one line under its name, because it does happen: *"Taking an update reloads the shell's plugins, so this window closes for a moment and comes back here with the result."*

## Notes

- Add and remove still hand off to a terminal — both genuinely ask questions and print what they did.
- The cache grows `changes`, `running` and `last` beside the existing `results`. An older build sharing that file rewrites it in the old shape and drops those fields; harmless once this is on `main`, worth knowing if you run both.

## Tested

- `bash -n` on the changed modules; Qt 6 `qmllint` on `Panel.qml` and `sections/PluginsSection.qml` (only pre-existing notes: the `Style` singleton qmllint cannot follow, and members it cannot see through the Loader's item); `omarchy plugin validate .`.
- Shell side against a stubbed upstream: the start returns in ~20ms with a spinner marker, the verdict lands a moment later, `results` is zeroed only on success, a refusal keeps upstream's message, and "already up to date" is not treated as an update.
- Live, in the running shell: window open on Plugins → Update → torn down (the journal shows the reload) → back on the Plugins page a couple of seconds later with the verdict on the row. Exercised on a real plugin by rewinding it one commit and letting the update pull it straight back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
