### PR TITLE
Move the window and its IPC route into the service

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1,69 +1,34 @@
 import QtQuick
-import Quickshell
-import Quickshell.Io
 import qs.Commons
 import qs.Ui
 
 // The bar's way into OmaSettings: a gear that opens the settings window.
 //
-// The window lives in SettingsWindow.qml and is loaded on first use rather
-// than at startup — the shell process is long-running and a settings window
-// nobody has opened yet should not cost it anything.
+// Nothing but the button lives here. The window and the IPC route are the
+// service's (Service.qml), which runs whenever the plugin is enabled, with or
+// without a bar entry — so removing the gear from the bar costs you the gear
+// and nothing else.
 BarWidget {
   id: root
   moduleName: "io.github.twiking.omasettings"
 
-  // The lifecycle a bar widget is expected to carry, in the names the rest of
-  // Omarchy uses. open/close and show/hide are the same pair twice, because
-  // both names are in circulation and neither is worth surprising anyone over.
-  readonly property bool opened: windowLoader.item ? windowLoader.item.shown : false
+  readonly property var service: bar && bar.shell && typeof bar.shell.serviceFor === "function"
+    ? bar.shell.serviceFor(moduleName) : null
 
-  function show() { windowLoader.active = true; if (windowLoader.item) windowLoader.item.show() }
-  // Opening on a named page is how a job that had to tear this window down
-  // brings it back where it was: the loader is asynchronous, so the page is
-  // remembered until there is an item to give it to.
-  property string pendingPage: ""
-  function showPage(page) {
-    pendingPage = String(page || "")
-    show()
-    applyPendingPage()
-  }
-  function applyPendingPage() {
-    if (pendingPage === "" || !windowLoader.item) return
-    windowLoader.item.pageId = pendingPage
-    pendingPage = ""
-  }
-  function hide() { if (windowLoader.item) windowLoader.item.hide() }
+  // Shape contract for shell.summon/hide/toggle routing: Bar.findPanelWidget
+  // requires open/close/opened on the bar-widget root, so the widget stands in
+  // for the window it does not own.
+  readonly property bool opened: service ? service.opened : false
+
+  function show() { if (service) service.show() }
+  function showPage(page) { if (service) service.showPage(page) }
+  function hide() { if (service) service.hide() }
   function open() { show() }
   function close() { hide() }
-  function toggle() {
-    if (opened) hide()
-    else show()
-  }
+  function toggle() { if (service) service.toggle() }
 
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
-
-  IpcHandler {
-    target: "omasettings"
-    function show(): void { root.show() }
-    function showPage(page: string): void { root.showPage(page) }
-    function hide(): void { root.hide() }
-    function open(): void { root.open() }
-    function close(): void { root.close() }
-    function toggle(): void { root.toggle() }
-  }
-
-  Loader {
-    id: windowLoader
-    active: false
-    asynchronous: true
-    source: "SettingsWindow.qml"
-    onLoaded: {
-      if (item) item.show()
-      root.applyPendingPage()
-    }
-  }
 
   BarIconButton {
     id: button
@@ -71,7 +36,7 @@ BarWidget {
     bar: root.bar
     text: "\uf013"
     tooltipText: "Settings"
-    active: windowLoader.item ? windowLoader.item.shown : false
+    active: root.opened
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.RightButton) root.bar.run("omarchy-menu")
       else root.toggle()

--- a/Service.qml
+++ b/Service.qml
@@ -1,19 +1,87 @@
 import QtQuick
 import Quickshell
+import Quickshell.Io
 
-// Installs the launcher entry, so the window is reachable from SUPER+SPACE
-// like any other application rather than only from the bar. Omarchy has no
-// install hook and no manifest field for registering one, so a plugin that
-// wants to be an app has to do it itself, on enable.
+// The plugin's always-on half: it owns the settings window and the IPC route
+// that opens it, and installs the launcher entry.
+//
+// The window lives here rather than in the bar widget because it is not the
+// bar's. A gear in the bar is one way in, `omarchy-shell omasettings toggle`
+// and the launcher entry are others, and the two should not depend on the
+// first: with the window in Panel.qml, taking the gear out of the bar takes
+// the plugin out of shell.json, and the plugin with it. Enabled through
+// `plugins[]` and with no bar entry at all, everything below still works.
+//
+// The launcher entry makes the window reachable from SUPER+SPACE like any
+// other application. Omarchy has no install hook and no manifest field for
+// registering one, so a plugin that wants to be an app has to do it itself,
+// on enable.
 //
 // Only a file carrying the X-OmaSettings-Managed marker is ever written or
 // deleted: an entry you wrote yourself at that path is left alone.
-QtObject {
+Scope {
   id: root
 
   property string omarchyPath: ""
   property var shell: null
   property var manifest: null
+
+  // ---------------- window lifecycle ---------------------------------------
+  //
+  // The lifecycle a plugin surface is expected to carry, in the names the rest
+  // of Omarchy uses. open/close and show/hide are the same pair twice, because
+  // both names are in circulation and neither is worth surprising anyone over.
+  //
+  // The window is loaded on first use rather than at startup — the shell
+  // process is long-running and a settings window nobody has opened yet should
+  // not cost it anything.
+  readonly property bool opened: windowLoader.item ? windowLoader.item.shown : false
+
+  function show() { windowLoader.active = true; if (windowLoader.item) windowLoader.item.show() }
+  // Opening on a named page is how a job that had to tear this window down
+  // brings it back where it was: the loader is asynchronous, so the page is
+  // remembered until there is an item to give it to.
+  property string pendingPage: ""
+  function showPage(page) {
+    pendingPage = String(page || "")
+    show()
+    applyPendingPage()
+  }
+  function applyPendingPage() {
+    if (pendingPage === "" || !windowLoader.item) return
+    windowLoader.item.pageId = pendingPage
+    pendingPage = ""
+  }
+  function hide() { if (windowLoader.item) windowLoader.item.hide() }
+  function open() { show() }
+  function close() { hide() }
+  function toggle() {
+    if (opened) hide()
+    else show()
+  }
+
+  IpcHandler {
+    target: "omasettings"
+    function show(): void { root.show() }
+    function showPage(page: string): void { root.showPage(page) }
+    function hide(): void { root.hide() }
+    function open(): void { root.open() }
+    function close(): void { root.close() }
+    function toggle(): void { root.toggle() }
+  }
+
+  Loader {
+    id: windowLoader
+    active: false
+    asynchronous: true
+    source: Qt.resolvedUrl("SettingsWindow.qml")
+    onLoaded: {
+      if (item) item.show()
+      root.applyPendingPage()
+    }
+  }
+
+  // ---------------- launcher entry -----------------------------------------
 
   readonly property string dest: Quickshell.env("HOME") + "/.local/share/applications/omasettings.desktop"
   readonly property string marker: "^X-OmaSettings-Managed=true$"


### PR DESCRIPTION
Taking the gear out of the bar currently takes the whole plugin with it.

Omarchy enables a third-party plugin iff its id appears in `shell.json`, and for a bar widget that means an entry in `bar.layout`. Since `Panel.qml` owns the window, the `omasettings` IPC target and — through the service it keeps alive — the launcher entry, removing that entry disables all three. `omarchy-shell omasettings toggle` answers `Target not found.`, the launcher entry is deleted, and a hotkey bound to it stops working. Someone who only wanted the bar space back loses every way into the window instead.

That happened to me: I dropped the gear from the bar, and only found out later that this was the same thing as uninstalling.

The window is not the bar's. This moves it, its loader and the `IpcHandler` into `Service.qml`, which the shell keeps alive for as long as the plugin is enabled, however it was enabled. `Panel.qml` keeps the button and forwards `show`/`hide`/`toggle` to the service it looks up through `bar.shell.serviceFor()`, keeping `open`/`close`/`opened` so it still satisfies `Bar.findPanelWidget`. `Service.qml` becomes a `Scope` rather than a `QtObject`, since it now has children.

With the plugin in `plugins[]` and no bar entry, the hotkey, the IPC and the launcher entry all work with no gear in the bar. Nothing needs to change for anyone: a bar entry with an empty `plugins[]` enables the service through the layout entry exactly as before.

**Testing**, following CLAUDE.md:

- `omarchy plugin validate .` — clean
- Qt 6 `qmllint -I` with the `qs` root — same warning categories as before the change (`missing-property` on `Loader.item` and on `bar`), no new ones
- the launcher cycle: `omarchy plugin disable` → entry gone → `omarchy plugin enable` → entry back → `desktop-file-validate` clean
- `omarchy restart shell` and the journal grepped for QML errors — clean
- `omarchy-shell shell summon` / `hide` routed through the bar widget — the window opens and closes, so the `open`/`close`/`opened` contract still holds
- all three arrangements exercised: `plugins[]` with no bar entry, a bar entry with empty `plugins[]`, and the gear clicked by hand